### PR TITLE
Typo segmentation_extract_rois_full_sig.py

### DIFF
--- a/src/bambird/segmentation_extract_rois_full_sig.py
+++ b/src/bambird/segmentation_extract_rois_full_sig.py
@@ -487,7 +487,7 @@ def extract_rois_full_sig(
             ax=ax3,
             title="3. mask",
             interpolation=None,
-            now=True,
+            now=False
         )
 
     # 6. get the mask with rois (im_rois) and the bounding box for each rois (rois_bbox)


### PR DESCRIPTION
Hi Sylvain, 
I think the reason the ROI plot hangs open is that the nrow parameter for maad.util.plot_spectrogram function should be set to False.
Many thanks,
Michela